### PR TITLE
feat: :sparkles: useUserStore hook

### DIFF
--- a/AuthProvider.tsx
+++ b/AuthProvider.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from "react";
 import {
-  User,
   onAuthStateChanged,
   signInWithEmailAndPassword,
   signOut,
@@ -8,14 +7,13 @@ import {
 } from "firebase/auth";
 import { doc, getDoc, setDoc } from "firebase/firestore";
 import { auth, db } from "./firebaseConfig";
+import { useUserStore } from "./hooks/UserStore";
 
 export type UserType = "user" | "admin" | null;
 
 interface AuthContextType {
-  user: User | null;
-  role: UserType | string;
   login: (email: string, password: string) => Promise<void>;
-  signup: (email: string, password: string, role: UserType) => Promise<void>;
+  signup: (email: string, password: string, role: string) => Promise<void>;
   logout: () => Promise<void>;
 }
 
@@ -23,31 +21,34 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 const ADMIN_UIDS = ["LlowqXkGoOPfY3mYGM0eVmWooDA3"];
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
-  const [user, setUser] = useState<User | null>(null);
-  const [role, setRole] = useState<UserType>(null);
+  const { setUser, clearUser } = useUserStore();
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
-      setUser(currentUser);
-
       if (currentUser) {
+        const userRef = doc(db, "users", currentUser.uid);
+        const userSnapshot = await getDoc(userRef);
+
+        let role = "user";
         if (ADMIN_UIDS.includes(currentUser.uid)) {
-          setRole("admin");
-        } else {
-          const roleDoc = await getDoc(doc(db, "users", currentUser.uid));
-          if (roleDoc.exists()) {
-            setRole(roleDoc.data().role);
-          } else {
-            setRole("user");
-          }
+          role = "admin";
+        } else if (userSnapshot.exists()) {
+          role = userSnapshot.data()?.role || "user";
         }
+
+        setUser({
+          id: currentUser.uid,
+          name: currentUser.displayName || "",
+          email: currentUser.email || "",
+          role,
+        });
       } else {
-        setRole(null);
+        clearUser();
       }
     });
 
     return unsubscribe;
-  }, []);
+  }, [setUser, clearUser]);
 
   const login = async (email: string, password: string) => {
     const userCredential = await signInWithEmailAndPassword(
@@ -57,19 +58,25 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     );
     const uid = userCredential.user.uid;
 
+    const userReference = doc(db, "users", uid);
+    const userSnapshot = await getDoc(userReference);
+
+    let role = "user";
     if (ADMIN_UIDS.includes(uid)) {
-      setRole("admin");
-    } else {
-      const roleDoc = await getDoc(doc(db, "users", uid));
-      if (roleDoc.exists()) {
-        setRole(roleDoc.data().role);
-      } else {
-        setRole("user");
-      }
+      role = "admin";
+    } else if (userSnapshot.exists()) {
+      role = userSnapshot.data()?.role || "user";
     }
+
+    setUser({
+      id: uid,
+      name: userCredential.user.displayName || "",
+      email: userCredential.user.email || "",
+      role,
+    });
   };
 
-  const signup = async (email: string, password: string, role: UserType) => {
+  const signup = async (email: string, password: string, role: string) => {
     const userCredential = await createUserWithEmailAndPassword(
       auth,
       email,
@@ -78,17 +85,24 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     const uid = userCredential.user.uid;
     const userRole = ADMIN_UIDS.includes(uid) ? "admin" : role;
 
-    await setDoc(doc(db, "users", uid), { role: userRole });
-    setRole(userRole);
+    const user = {
+      id: uid,
+      name: userCredential.user.displayName || "",
+      email: userCredential.user.email || "",
+      role: userRole,
+    };
+
+    await setDoc(doc(db, "users", uid), user);
+    clearUser();
   };
 
   const logout = async () => {
     await signOut(auth);
-    setRole(null);
+    clearUser();
   };
 
   return (
-    <AuthContext.Provider value={{ user, role, login, signup, logout }}>
+    <AuthContext.Provider value={{ login, signup, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/app/(admin)/adminHome.tsx
+++ b/app/(admin)/adminHome.tsx
@@ -1,10 +1,12 @@
 import { View, Text, Button } from "react-native";
 import { useAuth } from "../../AuthProvider";
 import { useRouter } from "expo-router";
+import { useUserStore } from "../../hooks/UserStore";
 
 const AdminHome = () => {
   const { logout } = useAuth();
-  console.log("Role:", useAuth().role);
+  const { user } = useUserStore();
+  console.log("Role:", user?.role);
   const router = useRouter();
 
   const navigateLogin = () => {

--- a/app/(auth)/authStyleSheet.ts
+++ b/app/(auth)/authStyleSheet.ts
@@ -14,14 +14,14 @@ const style = StyleSheet.create({
     borderWidth: 7,
     borderColor: "#FFA025",
   },
-  pageHeading : {
+  pageHeading: {
     fontSize: 20,
-    marginVertical: 10
+    marginVertical: 10,
   },
-  textBoxesContainer : {
+  textBoxesContainer: {
     width: "100%",
     marginBottom: 5,
-    marginTop: 60
+    marginTop: 60,
   },
   emailInput: {
     width: "100%",
@@ -35,7 +35,7 @@ const style = StyleSheet.create({
   requiredErrorText: {
     color: "red",
     minHeight: 20,
-    marginBottom: 10
+    marginBottom: 10,
   },
   passwordInputContainer: {
     width: "100%",
@@ -64,19 +64,19 @@ const style = StyleSheet.create({
   actionButtonText: {
     color: "white",
     textAlign: "center",
-    fontWeight: "bold"
+    fontWeight: "bold",
   },
   moveToAlternatePageLink: {
     marginTop: 10,
   },
-  highlitedText : {
+  highlitedText: {
     color: "#FFA025",
-    fontWeight: "bold"
+    fontWeight: "bold",
   },
   formikView: {
     width: "100%",
-    gap: 20
-  }
+    gap: 20,
+  },
 });
 
-export default style
+export default style;

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -16,6 +16,7 @@ import Ionicons from "@expo/vector-icons/Ionicons";
 // @ts-ignore
 import Logo from "../../assets/logo.svg";
 import style from "./authStyleSheet";
+import { useUserStore } from "../../hooks/UserStore";
 
 interface LoginFormValues {
   email: string;
@@ -23,7 +24,8 @@ interface LoginFormValues {
 }
 
 const LoginScreen = () => {
-  const { login, role } = useAuth();
+  const { login } = useAuth();
+  const { user, fetchUser } = useUserStore();
   const router = useRouter();
   const [showPassword, setShowPassword] = useState(false);
 
@@ -40,10 +42,14 @@ const LoginScreen = () => {
   });
 
   useEffect(() => {
-    if (role) {
-      router.replace(role === "admin" ? "/adminHome" : "/userHome");
+    fetchUser();
+  }, []);
+
+  useEffect(() => {
+    if (user?.role) {
+      router.replace(user.role === "admin" ? "/adminHome" : "/userHome");
     }
-  }, [role]);
+  }, [user?.role]);
 
   return (
     <KeyboardAvoidingView behavior="padding" style={style.mainContainer}>

--- a/app/(user)/userHome.tsx
+++ b/app/(user)/userHome.tsx
@@ -1,10 +1,12 @@
 import { View, Text, Button } from "react-native";
 import { useAuth } from "../../AuthProvider";
 import { useRouter } from "expo-router";
+import { useUserStore } from "../../hooks/UserStore";
 
 const UserHome = () => {
   const { logout } = useAuth();
-  console.log("Role:", useAuth().role);
+  const { user } = useUserStore();
+  console.log("Role:", user?.role);
   const router = useRouter();
 
   const navigateLogin = () => {

--- a/hooks/UserStore.ts
+++ b/hooks/UserStore.ts
@@ -1,0 +1,54 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { auth, db } from "../firebaseConfig";
+import { doc, getDoc, setDoc } from "firebase/firestore";
+
+interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+}
+
+interface UserStore {
+  user: User | null;
+  setUser: (user: User) => void;
+  clearUser: () => void;
+  fetchUser: () => Promise<User | null>;
+  updateUser: (user: User) => Promise<void>;
+}
+
+export const useUserStore = create<UserStore>()(
+  devtools((set, get) => ({
+    user: null,
+
+    setUser: (user: User) => set({ user }),
+
+    clearUser: () => set({ user: null }),
+
+    fetchUser: async () => {
+      const currentUser = auth.currentUser;
+      if (!currentUser) return null;
+
+      const userReference = doc(db, "users", currentUser.uid);
+      const userSnapshot = await getDoc(userReference);
+      if (!userSnapshot.exists()) return null;
+
+      const userData = userSnapshot.data();
+      const user = {
+        id: currentUser.uid,
+        name: userData.name,
+        email: userData.email,
+        role: userData.role,
+      };
+
+      set({ user });
+      return get().user;
+    },
+
+    updateUser: async (user: User) => {
+      await setDoc(doc(db, "users", user.id), user);
+      set({ user });
+    },
+  }))
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "react-native-screens": "~4.4.0",
         "react-native-svg": "^15.11.2",
         "react-native-svg-transformer": "^1.5.0",
-        "yup": "^1.6.1"
+        "yup": "^1.6.1",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -13701,6 +13702,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-native-screens": "~4.4.0",
     "react-native-svg": "^15.11.2",
     "react-native-svg-transformer": "^1.5.0",
-    "yup": "^1.6.1"
+    "yup": "^1.6.1",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
The UserStore stores the current user and manages it through reducers such as updateUser, fetchUser, clearUser and setUser.
This basically removes the direct user / role management from the AuthProvider . The AuthProvider  will be solely for the authentication. If in any screen we need to perform a certain function that will depend on the user, we will directly use the useUserStore  hook instead of having to first call the provider then get access to user details.